### PR TITLE
Made python3 compatible

### DIFF
--- a/pyfav/__init__.py
+++ b/pyfav/__init__.py
@@ -1,3 +1,0 @@
-from pyfav import get_favicon_url
-from pyfav import parse_markup_for_favicon
-from pyfav import download_favicon

--- a/pyfav/pyfav.py
+++ b/pyfav/pyfav.py
@@ -34,7 +34,10 @@ favicon_url = get_favicon_url('https://www.python.org/')
 
 
 import urllib, os.path, string
-from urlparse import urlparse
+try:
+  from urlparse import urlparse
+except:
+  from urllib.parse import urlparse
 import requests
 from bs4 import BeautifulSoup
 


### PR DESCRIPTION
Some minor changes make it python3 compatible.
I had to change the **init**.py but was a bit unclear on why it had the references to begin with? A blank **init**.py should have it functioning the same, yes?
